### PR TITLE
fix both labs

### DIFF
--- a/imagekit.ijt
+++ b/imagekit.ijt
@@ -104,6 +104,7 @@ NB. =========================================================
 Lab Section Palettes
 A common 8-bit image format consists of a palette and an array of indices into the palette representing the pixels. Such a format is useful for abstract images with few colors but may also be used to approximate a full color image. In that case, quality is lost in exchange for smaller size. The function quantize_image allows us to create a palette of the specified size and the array suitable for saving.
 )
+B=:read_image im1
 B write_image im_path,'temp.bmp'
 (C256=:256 quantize_image B) write_image im_path,'atk256.bmp'
 (C16=:16 quantize_image B) write_image im_path,'atk016.png'

--- a/imagekit_ja.ijt
+++ b/imagekit_ja.ijt
@@ -104,6 +104,7 @@ NB. =========================================================
 Lab Section Palettes
 A common 8-bit image format consists of a palette and an array of indices into the palette representing the pixels. Such a format is useful for abstract images with few colors but may also be used to approximate a full color image. In that case, quality is lost in exchange for smaller size. The function quantize_image allows us to create a palette of the specified size and the array suitable for saving.
 )
+B=:read_image im1
 B write_image im_path,'temp.png'
 (C256=:256 quantize_image B) write_image im_path,'atk256.png'
 (C16=:16 quantize_image B) write_image im_path,'atk016.png'

--- a/manifest.ijs
+++ b/manifest.ijs
@@ -8,7 +8,7 @@ The image kit package provides utilities for accessing 24-bit jpeg, png image fi
 The addon includes several scripts. The main script, imagekit.ijs, provides J functions for the basic image reading, writing, and viewing images through other J addons. Another script, html_gallery.ijs, provides J functions that create thumbnails and image galleries under J program control. Sample scripts and a rotation form script are also included.
 )
 
-VERSION=: '1.0.9'
+VERSION=: '1.0.10'
 
 RELEASE=: ''
 


### PR DESCRIPTION
As a result of the correct execution of read_image_raw in section 9 of 19 variable B is overwritten. quantize_image function is not suited to work with raw data, so it returns an error in section 13 of 19. The solution is to overwrite the B variable again at the beginning of the section 13 of 19.